### PR TITLE
Remove VITC mention in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Typical applications of UE with DELTACAST cards :
 - Support of DELTACAST SDI, HDMI and DisplayPort I/Os 
 - Resolutions from SD up to 8K60 
 - Genlock support : can lock the UE frame rate to match the reference input video 
-- Timecode support : UE frame timecode can match the timecode of the SDI input video feed (LTC/VITC)
+- Timecode support : UE frame timecode can match the timecode of the SDI input video feed (LTC)
 - Support of RGBA 8-bit and YUV 422 8-bit/10-bit textures
 - Handle DELTACAST board configuration
 


### PR DESCRIPTION
Indeed, only LTC timecode is implemented for now.